### PR TITLE
feat: match new express-crud-router version with only `get` action.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,1 @@
-Changes are documented in the [Github releases page](https://github.com/lalalilo/express-crud-router-sequelize-v6-router/releases)
+Changes are documented in the [Github releases page](https://github.com/nicgirault/express-crud-router-sequelize-v6-router/releases)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Sequelize v6 connector to [express-crud-router](https://github.com/lalalilo/express-crud-router).
 
 ```ts
-import crud from "express-crud-router";
-import sequelizeV6Crud from "express-crud-router-sequelize-v6-router";
+import crud from 'express-crud-router'
+import sequelizeV6Crud from 'express-crud-router-sequelize-v6-router'
 
-app.use(crud("/admin/users", sequelizeV6Crud(User)));
+app.use(crud('/admin/users', sequelizeV6Crud(User)))
 ```
 
 ## Install
@@ -22,33 +22,30 @@ express-crud-router-sequelize-v6-router exposes a default search helper function
 Here is an example:
 
 ```ts
-import crud from "express-crud-router";
+import crud from 'express-crud-router'
 import sequelizeCrud, {
-  sequelizeSearchFields,
-} from "express-crud-router-sequelize-v6-connector";
+  simpleSequelizeSearch,
+} from 'express-crud-router-sequelize-v6-connector'
 
-crud("/admin/users", {
-  ...sequelizeCrud(User),
-  search: sequelizeSearchFields(User, ["address", "zipCode", "city"]),
-});
+crud('/admin/users', sequelizeCrud(User), {
+  filters: {
+    q: simpleSequelizeSearch(User, ['address', 'zipCode', 'city']),
+  },
+})
 ```
 
-When searching `some stuff`, the following records will be returned in this order:
+When searching `some stuff`, records with a searchable field that contains `some stuff` will be returned.
 
-1. records with a searchable field that contains `some stuff`
-2. records that have searchable fields that contain both `some` and `stuff`
-3. records that have searchable fields that contain one of `some` or `stuff`
-
-The search is case insensitive by default (except for search fields of type `DataTypes.UUID` where exact matches are returned). You can customize the search to make it case sensitive or use a scope:
+The search is case insensitive by default (except for search fields of type `DataTypes.UUID` where exact matches are returned). You can customize the search to make it case sensitive:
 
 ```ts
-import { Op } from "sequelize";
+import { Op } from 'sequelize'
 
-const search = sequelizeSearchFields(
+const search = simpleSequelizeSearch(
   User,
-  ["address", "zipCode", "city"],
+  ['address', 'zipCode', 'city'],
   Op.like
-);
+)
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # express-crud-router-sequelize-v6-connector
 
-Sequelize v6 connector to [express-crud-router](https://github.com/lalalilo/express-crud-router).
+Sequelize v6 connector to [express-crud-router](https://github.com/nicgirault/express-crud-router).
 
 ```ts
 import crud from 'express-crud-router'
@@ -50,4 +50,4 @@ const search = simpleSequelizeSearch(
 
 ## Contribute
 
-See https://github.com/lalalilo/express-crud-router#contribute
+See https://github.com/nicgirault/express-crud-router#contribute

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lalalilo/express-crud-router-sequelize-v6-connector.git"
+    "url": "git+https://github.com/nicgirault/express-crud-router-sequelize-v6-connector.git"
   },
   "author": "nicgirault <nic.girault@gmail.com>",
   "keywords": [
@@ -24,9 +24,9 @@
     "sequelize"
   ],
   "bugs": {
-    "url": "https://github.com/lalalilo/express-crud-router-sequelize-v6-connector/issues"
+    "url": "https://github.com/nicgirault/express-crud-router-sequelize-v6-connector/issues"
   },
-  "homepage": "https://github.com/lalalilo/express-crud-router-sequelize-v6-connector#readme",
+  "homepage": "https://github.com/nicgirault/express-crud-router-sequelize-v6-connector#readme",
   "license": "MIT",
   "scripts": {
     "build": "rimraf lib && babel src -d lib --extensions '.ts' && tsc",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -8,7 +8,6 @@ describe('sequelizeCrud', () => {
     expect(actions.create).toBeDefined()
     expect(actions.destroy).toBeDefined()
     expect(actions.update).toBeDefined()
-    expect(actions.getList).toBeDefined()
-    expect(actions.getOne).toBeDefined()
+    expect(actions.get).toBeDefined()
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,6 @@ interface Actions<
   Attributes extends { id: string | number },
   CreationAttributes extends {} = Attributes
 > {
-  getOne: (
-    identifier: Attributes['id']
-  ) => Promise<Model<Attributes, CreationAttributes> | null>
   create: (
     body: CreationAttributes
   ) => Promise<Model<Attributes, CreationAttributes>>
@@ -15,7 +12,7 @@ interface Actions<
     id: Attributes['id'],
     data: Partial<Attributes>
   ) => Promise<Model<Attributes, CreationAttributes>>
-  getList: (conf: {
+  get: (conf: {
     filter: Record<string, any>
     limit: number
     offset: number
@@ -41,8 +38,7 @@ const sequelizeCrud = <
       }
       return record.update(body)
     },
-    getOne: async id => model.findByPk(id),
-    getList: async ({ filter, limit, offset, order }) => {
+    get: async ({ filter, limit, offset, order }) => {
       return model.findAndCountAll({
         limit,
         offset,

--- a/src/searchList.ts
+++ b/src/searchList.ts
@@ -1,88 +1,26 @@
-import { uniqBy, flatten } from 'lodash'
-import { Op, WhereOptions, DataTypes, ModelStatic, Model } from 'sequelize'
+import { Op, DataTypes, ModelStatic, Model, WhereOptions } from 'sequelize'
 
-export const sequelizeSearchFields =
+export const simpleSequelizeSearch =
   <Attributes extends {}>(
     model: ModelStatic<Model<Attributes>>,
     searchableFields: (keyof Attributes)[],
     comparator: symbol = Op.iLike
-  ) =>
-  async (q: string, limit: number, scope: WhereOptions<Attributes> = {}) => {
-    const resultChunks = await Promise.all(
-      prepareQueries<Attributes>(model, searchableFields)(q, comparator).map(
-        query =>
-          model.findAll({
-            limit,
-            where: { ...query, ...scope },
-            raw: true,
-          })
-      )
-    )
-
-    const rows = uniqBy(flatten(resultChunks).slice(0, limit), 'id')
-
-    return { rows, count: rows.length }
-  }
+  ) => (q: string): WhereOptions<Attributes> => ({
+    [Op.or]: searchableFields.map(field => ({
+      [field]: getSearchTerm(model, field, comparator, q),
+    })),
+  })
 
 const getSearchTerm = <Attributes extends {}>(
   model: ModelStatic<Model<Attributes>>,
   field: keyof Attributes,
   comparator: symbol,
-  token: string
+  query: string
 ) => {
   if (
     String(model.rawAttributes[field as string].type) === String(DataTypes.UUID)
   ) {
-    return { [Op.eq]: token }
+    return { [Op.eq]: query }
   }
-  return { [comparator]: `%${token}%` }
+  return { [comparator]: `%${query}%` }
 }
-
-export const prepareQueries =
-  <Attributes>(
-    model: ModelStatic<Model<Attributes>>,
-    searchableFields: (keyof Attributes)[]
-  ) =>
-  (q: string, comparator: symbol = Op.iLike): WhereOptions<Attributes>[] => {
-    if (!searchableFields) {
-      // TODO: we could propose a default behavior based on model rawAttributes
-      // or (maybe better) based on existing indexes. This can be complexe
-      // because we have to deal with column types
-      throw new Error(
-        'You must provide searchableFields option to use the "q" filter in express-sequelize-crud'
-      )
-    }
-
-    const defaultQuery = {
-      [Op.or]: searchableFields.map(field => ({
-        [field]: getSearchTerm(model, field, comparator, q),
-      })),
-    }
-
-    const tokens = q.split(/\s+/).filter(token => token !== '')
-    if (tokens.length < 2) return [defaultQuery]
-
-    // query consists of multiple tokens => do multiple searches
-    return [
-      // priority to unsplit match
-      defaultQuery,
-
-      // then search records with all tokens
-      {
-        [Op.and]: tokens.map(token => ({
-          [Op.or]: searchableFields.map(field => ({
-            [field]: getSearchTerm(model, field, comparator, token),
-          })),
-        })),
-      },
-
-      // then search records with at least one token
-      {
-        [Op.or]: tokens.map(token => ({
-          [Op.or]: searchableFields.map(field => ({
-            [field]: getSearchTerm(model, field, comparator, token),
-          })),
-        })),
-      },
-    ]
-  }


### PR DESCRIPTION
BREAKING CHANGE: the search helper is no providing a function to be passed in the crud custom filters. It does not anymore generate 3 queries to the database but a more basic one.